### PR TITLE
xcor1d and todcor test additions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 	     "pandas",
 	     "specutils",
 	     "pytest",
+	     "scikit-image",
 ]
 requires-python = ">=3.10"
 authors = [

--- a/pytodcor/xcor/todcor.py
+++ b/pytodcor/xcor/todcor.py
@@ -33,7 +33,7 @@ def _find_rel_shift(lag_i, lag_j):
     """
     return lag_j - lag_i
 
-def todcor(obs_spec, model_1, model_2, n_pix_shifts, fixed_alpha=None, vel_range=None):
+def todcor(obs_spec, model_1, model_2, n_pix_shifts, fixed_alpha=None, vel_range=None, debug=False):
     """
     Performs two-dimensional cross-correlation given an observed spectrum and two model spectra to
     use as templates. Spectral wavelengths are assumed to be in the same units between the observed
@@ -61,9 +61,6 @@ def todcor(obs_spec, model_1, model_2, n_pix_shifts, fixed_alpha=None, vel_range
                        correlation values, and a two-dimensional array of TODCOR scaling
                        ratios between the two templates.
     """
-
-    # DEBUG
-    debug = True
 
     # Set a velocity range limit if none is provided.
     if not vel_range:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ matplotlib>=3.7.2
 numpy>=1.25.2
 pandas>=2.0.3
 specutils>=1.11.0
+scikit-image>=0.25.2
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
   pandas
   specutils
   scipy
+  scikit-image
   notebook
 
 [options.entry_points]

--- a/tests/basic/test_todcor_case01.py
+++ b/tests/basic/test_todcor_case01.py
@@ -2,245 +2,71 @@ import pytest
 import numpy as np
 from astropy import units as u
 from scipy.stats import norm
-from scipy.signal import find_peaks
+from skimage.feature import peak_local_max
 from specutils.spectra import Spectrum
 from pytodcor.xcor.todcor import todcor
 from pytodcor.lib.spectrum import PytodcorSpectrum
 
-class Test01:
-    def setup_class(cls):
+class TestCase01:
+    """
+    Identical x-axis, Identical Gaussians, No Template Shifts
+    """
+    def setup_class(self):
         # Generate the Gaussians to use.
-        cls.gauss_1_peak = 5380.
-        cls.gauss_2_peak = 5420.
-        cls.xvals = np.linspace(5300., 5500., 1000)
-        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
-        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
-        cls.obs_y = cls.g1_y + cls.g2_y
-        cls.mod1_y = cls.g1_y
-        cls.mod2_y = cls.g2_y
+        gauss_1_peak = 5380.
+        gauss_2_peak = 5420.
+        xvals = np.linspace(5300., 5500., 1000)
+        g1_y = norm.pdf(xvals, gauss_1_peak, 4.)
+        g2_y = norm.pdf(xvals, gauss_2_peak, 4.)
+        # Double-peaked Gaussian
+        obs_y = g1_y + g2_y
+        # Two single-peaked Gaussians
+        mod1_y = g1_y
+        mod2_y = g2_y
 
-        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
+        # This is the separation before log-linear resampling.
+        self.n_pix_apart = len(np.where((xvals >= gauss_1_peak) & (xvals <= gauss_2_peak))[0])
+        # This is the expected shift after log-linear resampling.
+        self.n_pix_apart_loglin = 203
 
-        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
-                                  spectral_axis=cls.xvals * u.angstrom)
-        cls.obs_spec = PytodcorSpectrum(name="Case_01_Obs", air_or_vac="vacuum")
-        cls.obs_spec.add_spec_part(cls.obs_spec1d)
+        obs_spec1d = Spectrum(flux=obs_y * u.dimensionless_unscaled,
+                                  spectral_axis=xvals * u.angstrom)
+        obs_spec = PytodcorSpectrum(name="Case_01_Obs", air_or_vac="vacuum")
+        obs_spec.add_spec_part(obs_spec1d)
 
-        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod1_spec = PytodcorSpectrum(name="Case_01_Mod1", air_or_vac="vacuum")
-        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
+        mod1_spec1d = Spectrum(flux=mod1_y * u.dimensionless_unscaled,
+                                   spectral_axis=xvals * u.angstrom)
+        mod1_spec = PytodcorSpectrum(name="Case_01_Mod1", air_or_vac="vacuum")
+        mod1_spec.add_spec_part(mod1_spec1d)
 
-        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod2_spec = PytodcorSpectrum(name="Case_01_Mod2", air_or_vac="vacuum")
-        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
+        mod2_spec1d = Spectrum(flux=mod2_y * u.dimensionless_unscaled,
+                                   spectral_axis=xvals * u.angstrom)
+        mod2_spec = PytodcorSpectrum(name="Case_01_Mod2", air_or_vac="vacuum")
+        mod2_spec.add_spec_part(mod2_spec1d)
 
-        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
-            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
+        self.todcor_pixshifts, self.vel_per_pix, self.todcor_vals, self.todcor_alphas = todcor(
+            obs_spec.parts[0], mod1_spec.parts[0], mod2_spec.parts[0], 400,
             fixed_alpha=1., vel_range=[-500., 500.]
         )
-        cls.x_fix_shift_1 = 0
-        cls.x_fix_shift_2 = cls.n_pix_apart
-        cls.y_fix_shift_1 = 0
-        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
-        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
-        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
-        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
-        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
-    def test_primary_zero_shift(self):
-        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
-        assert peak1_pri_shift0 == pytest.approx(-203, abs=1)
-        assert peak2_pri_shift0 == pytest.approx(0, abs=1)
-    def test_primary_nonzero_shift(self):
-        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
-        assert peak1_pri_shift200 == pytest.approx(-203, abs=1)
-        assert peak2_pri_shift200 == pytest.approx(0, abs=1)
-    def test_secondary_zero_shift(self):
-        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
-        assert peak1_sec_shift0 == pytest.approx(0, abs=1)
-        assert peak2_sec_shift0 == pytest.approx(203, abs=1)
-    def test_secondary_nonzero_shift(self):
-        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
-        assert peak1_sec_shift200 == pytest.approx(0, abs=1)
-        assert peak2_sec_shift200 == pytest.approx(203, abs=1)
 
+    def test_case_01(self):
+        # Find local max peaks within the two-dimensional TODCOR array.
+        # The return are indices, which can be indexed into the "pixshifts" to translate into lag values.
+        twod_peaks = peak_local_max(self.todcor_vals, min_distance=4)
+        # Strongest peak at (0,0)
+        assert np.array_equal(self.todcor_pixshifts[twod_peaks[0]], np.asarray([0, 0]))
+        # Second strongest peak at (n_pix_apart_loglin, -1*n_pix_apart_loglin)
+        assert np.array_equal(self.todcor_pixshifts[twod_peaks[1]],
+                                  np.asarray([self.n_pix_apart_loglin, -1*self.n_pix_apart_loglin]))
+        # Third and fourth strongest peaks at (0, -1* n_pix_apart_loglin) or (n_pix_apart_loglin, 0), don't assume an order.
+        assert (
+            np.array_equal(self.todcor_pixshifts[twod_peaks[2]], np.asarray([0, -1*self.n_pix_apart_loglin]))
+            or
+            np.array_equal(self.todcor_pixshifts[twod_peaks[2]], np.asarray([self.n_pix_apart_loglin, 0]))
+            )
 
-
-class Test02:
-    def setup_class(cls):
-        # Generate the Gaussians to use.
-        cls.gauss_1_peak = 5370.
-        cls.gauss_2_peak = 5430.
-        cls.xvals = np.linspace(5300., 5500., 1000)
-        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
-        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
-        cls.obs_y = cls.g1_y + cls.g2_y
-        cls.mod1_y = cls.g1_y
-        cls.mod2_y = cls.g2_y
-
-        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
-
-        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
-                                  spectral_axis=cls.xvals * u.angstrom)
-        cls.obs_spec = PytodcorSpectrum(name="Case_02_Obs", air_or_vac="vacuum")
-        cls.obs_spec.add_spec_part(cls.obs_spec1d)
-
-        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod1_spec = PytodcorSpectrum(name="Case_02_Mod1", air_or_vac="vacuum")
-        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
-
-        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod2_spec = PytodcorSpectrum(name="Case_02_Mod2", air_or_vac="vacuum")
-        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
-
-        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
-            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
-            fixed_alpha=1., vel_range=[-500., 500.]
-        )
-        cls.x_fix_shift_1 = 0
-        cls.x_fix_shift_2 = cls.n_pix_apart
-        cls.y_fix_shift_1 = 0
-        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
-        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
-        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
-        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
-        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
-
-    def test_primary_zero_shift(self):
-        peak1_pri_zero_shift, peak2_pri_zero_shift = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
-        assert peak1_pri_zero_shift == pytest.approx(-304, abs=1)
-        assert peak2_pri_zero_shift == pytest.approx(0, abs=2)
-    def test_primary_nonzero_shift(self):
-        peak1_pri_nonzero_shift, peak2_pri_nonzero_shift = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
-        assert peak1_pri_nonzero_shift == pytest.approx(-304, abs=1)
-        assert peak2_pri_nonzero_shift == pytest.approx(0, abs=2)
-    def test_secondary_zero_shift(self):
-        peak1_sec_zero_shift, peak2_sec_zero_shift = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
-        assert peak1_sec_zero_shift == pytest.approx(0, abs=2)
-        assert peak2_sec_zero_shift == pytest.approx(304, abs=1)
-    def test_secondary_nonzero_shift(self):
-        peak1_sec_nonzero_shift, peak2_sec_nonzero_shift = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
-        assert peak1_sec_nonzero_shift == pytest.approx(0, abs=2)
-        assert peak2_sec_nonzero_shift == pytest.approx(304, abs=1)
-
-class Test03:
-    def setup_class(cls):
-        # Generate the Gaussians to use (identical peaks).
-        cls.gauss_1_peak = 5400.
-        cls.gauss_2_peak = 5400.
-        cls.xvals = np.linspace(5300., 5500., 1000)
-        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
-        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
-        cls.obs_y = cls.g1_y + cls.g2_y
-        cls.mod1_y = cls.g1_y
-        cls.mod2_y = cls.g2_y
-
-        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
-
-        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
-                                  spectral_axis=cls.xvals * u.angstrom)
-        cls.obs_spec = PytodcorSpectrum(name="Case_03_Obs", air_or_vac="vacuum")
-        cls.obs_spec.add_spec_part(cls.obs_spec1d)
-
-        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod1_spec = PytodcorSpectrum(name="Case_03_Mod1", air_or_vac="vacuum")
-        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
-
-        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod2_spec = PytodcorSpectrum(name="Case_03_Mod2", air_or_vac="vacuum")
-        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
-
-        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
-            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
-            fixed_alpha=1., vel_range=[-500., 500.]
-        )
-        cls.x_fix_shift_1 = 0
-        cls.x_fix_shift_2 = cls.n_pix_apart
-        cls.y_fix_shift_1 = 0
-        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
-        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
-        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
-        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
-        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
-    # NO TOLERANCE -- PEAK SHOULD BE ZERO FOR ALL
-    def test_primary_zero_shift(self):
-        peak = (find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400)[0]
-        assert peak == 0
-
-    def test_primary_nonzero_shift(self):
-        peak = (find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400)[0]
-        assert peak == 0
-
-    def test_secondary_zero_shift(self):
-        peak = (find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400)[0]
-        assert peak == 0
-
-    def test_secondary_nonzero_shift(self):
-        peak = (find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400)[0]
-        assert peak == 0
-class Test04:
-    def setup_class(cls):
-        # Generate the Gaussians to use (smaller width, unequal amplitudes, different spectral range)
-        cls.gauss_1_peak = 4080.
-        cls.gauss_2_peak = 4120.
-        cls.xvals = np.linspace(4000., 4200., 1000)
-        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 1.)
-        cls.g2_y = 0.1 * norm.pdf(cls.xvals, cls.gauss_2_peak, 1.)  # Second Gaussian has 10% amplitude
-        cls.obs_y = cls.g1_y + cls.g2_y
-        cls.mod1_y = cls.g1_y
-        cls.mod2_y = cls.g2_y
-
-        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
-
-        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
-                                  spectral_axis=cls.xvals * u.angstrom)
-        cls.obs_spec = PytodcorSpectrum(name="Case_04_Obs", air_or_vac="vacuum")
-        cls.obs_spec.add_spec_part(cls.obs_spec1d)
-
-        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod1_spec = PytodcorSpectrum(name="Case_04_Mod1", air_or_vac="vacuum")
-        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
-
-        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
-                                   spectral_axis=cls.xvals * u.angstrom)
-        cls.mod2_spec = PytodcorSpectrum(name="Case_04_Mod2", air_or_vac="vacuum")
-        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
-
-        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
-            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
-            fixed_alpha=1., vel_range=[-500., 500.]
-        )
-        cls.x_fix_shift_1 = 0
-        cls.x_fix_shift_2 = cls.n_pix_apart
-        cls.y_fix_shift_1 = 0
-        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
-        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
-        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
-        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
-        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
-
-    def test_primary_zero_shift(self):
-        peak1_pri_zero_shift, peak2_pri_zero_shift = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
-        assert peak1_pri_zero_shift == pytest.approx(-204, abs=1)
-        assert peak2_pri_zero_shift == pytest.approx(0, abs=1)
-
-    def test_primary_nonzero_shift(self):
-        peak1_pri_nonzero_shift, peak2_pri_nonzero_shift = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
-        assert peak1_pri_nonzero_shift == pytest.approx(-204, abs=1)
-        assert peak2_pri_nonzero_shift == pytest.approx(0, abs=1)
-
-    def test_secondary_zero_shift(self):
-        peak1_sec_zero_shift, peak2_sec_zero_shift = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
-        assert peak1_sec_zero_shift == pytest.approx(0, abs=1)
-        assert peak2_sec_zero_shift == pytest.approx(204, abs=1)
-
-    def test_secondary_nonzero_shift(self):
-        peak1_sec_nonzero_shift, peak2_sec_nonzero_shift = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
-        assert peak1_sec_nonzero_shift == pytest.approx(0, abs=1)
-        assert peak2_sec_nonzero_shift == pytest.approx(204, abs=1)
+        assert (
+            np.array_equal(self.todcor_pixshifts[twod_peaks[3]], np.asarray([0, -1*self.n_pix_apart_loglin]))
+            or
+            np.array_equal(self.todcor_pixshifts[twod_peaks[3]], np.asarray([self.n_pix_apart_loglin, 0]))
+            )

--- a/tests/basic/test_todcor_case01.py
+++ b/tests/basic/test_todcor_case01.py
@@ -110,25 +110,21 @@ class Test02:
         cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
 
     def test_primary_zero_shift(self):
-        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
-        assert peak1_pri_shift0 == pytest.approx(-304, abs=1)
-        assert peak2_pri_shift0 == pytest.approx(0, abs=2)
-
+        peak1_pri_zero_shift, peak2_pri_zero_shift = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
+        assert peak1_pri_zero_shift == pytest.approx(-304, abs=1)
+        assert peak2_pri_zero_shift == pytest.approx(0, abs=2)
     def test_primary_nonzero_shift(self):
-        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
-        assert peak1_pri_shift200 == pytest.approx(-304, abs=1)
-        assert peak2_pri_shift200 == pytest.approx(0, abs=2)
-
+        peak1_pri_nonzero_shift, peak2_pri_nonzero_shift = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
+        assert peak1_pri_nonzero_shift == pytest.approx(-304, abs=1)
+        assert peak2_pri_nonzero_shift == pytest.approx(0, abs=2)
     def test_secondary_zero_shift(self):
-        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
-        assert peak1_sec_shift0 == pytest.approx(0, abs=2)
-        assert peak2_sec_shift0 == pytest.approx(304, abs=1)
-
+        peak1_sec_zero_shift, peak2_sec_zero_shift = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
+        assert peak1_sec_zero_shift == pytest.approx(0, abs=2)
+        assert peak2_sec_zero_shift == pytest.approx(304, abs=1)
     def test_secondary_nonzero_shift(self):
-        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
-        assert peak1_sec_shift200 == pytest.approx(0, abs=2)
-        assert peak2_sec_shift200 == pytest.approx(304, abs=1)
-
+        peak1_sec_nonzero_shift, peak2_sec_nonzero_shift = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
+        assert peak1_sec_nonzero_shift == pytest.approx(0, abs=2)
+        assert peak2_sec_nonzero_shift == pytest.approx(304, abs=1)
 
 class Test03:
     def setup_class(cls):
@@ -230,21 +226,21 @@ class Test04:
         cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
 
     def test_primary_zero_shift(self):
-        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
-        assert peak1_pri_shift0 == pytest.approx(-204, abs=1)
-        assert peak2_pri_shift0 == pytest.approx(0, abs=1)
+        peak1_pri_zero_shift, peak2_pri_zero_shift = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
+        assert peak1_pri_zero_shift == pytest.approx(-204, abs=1)
+        assert peak2_pri_zero_shift == pytest.approx(0, abs=1)
 
     def test_primary_nonzero_shift(self):
-        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
-        assert peak1_pri_shift200 == pytest.approx(-204, abs=1)
-        assert peak2_pri_shift200 == pytest.approx(0, abs=1)
+        peak1_pri_nonzero_shift, peak2_pri_nonzero_shift = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
+        assert peak1_pri_nonzero_shift == pytest.approx(-204, abs=1)
+        assert peak2_pri_nonzero_shift == pytest.approx(0, abs=1)
 
     def test_secondary_zero_shift(self):
-        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
-        assert peak1_sec_shift0 == pytest.approx(0, abs=1)
-        assert peak2_sec_shift0 == pytest.approx(204, abs=1)
+        peak1_sec_zero_shift, peak2_sec_zero_shift = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
+        assert peak1_sec_zero_shift == pytest.approx(0, abs=1)
+        assert peak2_sec_zero_shift == pytest.approx(204, abs=1)
 
     def test_secondary_nonzero_shift(self):
-        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
-        assert peak1_sec_shift200 == pytest.approx(0, abs=1)
-        assert peak2_sec_shift200 == pytest.approx(204, abs=1)
+        peak1_sec_nonzero_shift, peak2_sec_nonzero_shift = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
+        assert peak1_sec_nonzero_shift == pytest.approx(0, abs=1)
+        assert peak2_sec_nonzero_shift == pytest.approx(204, abs=1)

--- a/tests/basic/test_todcor_case01.py
+++ b/tests/basic/test_todcor_case01.py
@@ -49,7 +49,7 @@ class TestCase01:
             fixed_alpha=1., vel_range=[-500., 500.]
         )
 
-    def test_case_01(self):
+    def test_todcor_case01(self):
         # Find local max peaks within the two-dimensional TODCOR array.
         # The return are indices, which can be indexed into the "pixshifts" to translate into lag values.
         twod_peaks = peak_local_max(self.todcor_vals, min_distance=4)

--- a/tests/basic/test_todcor_case01.py
+++ b/tests/basic/test_todcor_case01.py
@@ -1,0 +1,250 @@
+import pytest
+import numpy as np
+from astropy import units as u
+from scipy.stats import norm
+from scipy.signal import find_peaks
+from specutils.spectra import Spectrum
+from pytodcor.xcor.todcor import todcor
+from pytodcor.lib.spectrum import PytodcorSpectrum
+
+class Test01:
+    def setup_class(cls):
+        # Generate the Gaussians to use.
+        cls.gauss_1_peak = 5380.
+        cls.gauss_2_peak = 5420.
+        cls.xvals = np.linspace(5300., 5500., 1000)
+        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
+        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
+        cls.obs_y = cls.g1_y + cls.g2_y
+        cls.mod1_y = cls.g1_y
+        cls.mod2_y = cls.g2_y
+
+        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
+
+        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
+                                  spectral_axis=cls.xvals * u.angstrom)
+        cls.obs_spec = PytodcorSpectrum(name="Case_01_Obs", air_or_vac="vacuum")
+        cls.obs_spec.add_spec_part(cls.obs_spec1d)
+
+        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod1_spec = PytodcorSpectrum(name="Case_01_Mod1", air_or_vac="vacuum")
+        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
+
+        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod2_spec = PytodcorSpectrum(name="Case_01_Mod2", air_or_vac="vacuum")
+        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
+
+        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
+            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
+            fixed_alpha=1., vel_range=[-500., 500.]
+        )
+        cls.x_fix_shift_1 = 0
+        cls.x_fix_shift_2 = cls.n_pix_apart
+        cls.y_fix_shift_1 = 0
+        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
+        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
+        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
+        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
+        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
+    def test_primary_zero_shift(self):
+        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
+        assert peak1_pri_shift0 == pytest.approx(-203, abs=1)
+        assert peak2_pri_shift0 == pytest.approx(0, abs=1)
+    def test_primary_nonzero_shift(self):
+        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
+        assert peak1_pri_shift200 == pytest.approx(-203, abs=1)
+        assert peak2_pri_shift200 == pytest.approx(0, abs=1)
+    def test_secondary_zero_shift(self):
+        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
+        assert peak1_sec_shift0 == pytest.approx(0, abs=1)
+        assert peak2_sec_shift0 == pytest.approx(203, abs=1)
+    def test_secondary_nonzero_shift(self):
+        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
+        assert peak1_sec_shift200 == pytest.approx(0, abs=1)
+        assert peak2_sec_shift200 == pytest.approx(203, abs=1)
+
+
+
+class Test02:
+    def setup_class(cls):
+        # Generate the Gaussians to use.
+        cls.gauss_1_peak = 5370.
+        cls.gauss_2_peak = 5430.
+        cls.xvals = np.linspace(5300., 5500., 1000)
+        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
+        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
+        cls.obs_y = cls.g1_y + cls.g2_y
+        cls.mod1_y = cls.g1_y
+        cls.mod2_y = cls.g2_y
+
+        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
+
+        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
+                                  spectral_axis=cls.xvals * u.angstrom)
+        cls.obs_spec = PytodcorSpectrum(name="Case_02_Obs", air_or_vac="vacuum")
+        cls.obs_spec.add_spec_part(cls.obs_spec1d)
+
+        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod1_spec = PytodcorSpectrum(name="Case_02_Mod1", air_or_vac="vacuum")
+        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
+
+        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod2_spec = PytodcorSpectrum(name="Case_02_Mod2", air_or_vac="vacuum")
+        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
+
+        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
+            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
+            fixed_alpha=1., vel_range=[-500., 500.]
+        )
+        cls.x_fix_shift_1 = 0
+        cls.x_fix_shift_2 = cls.n_pix_apart
+        cls.y_fix_shift_1 = 0
+        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
+        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
+        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
+        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
+        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
+
+    def test_primary_zero_shift(self):
+        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
+        assert peak1_pri_shift0 == pytest.approx(-304, abs=1)
+        assert peak2_pri_shift0 == pytest.approx(0, abs=2)
+
+    def test_primary_nonzero_shift(self):
+        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
+        assert peak1_pri_shift200 == pytest.approx(-304, abs=1)
+        assert peak2_pri_shift200 == pytest.approx(0, abs=2)
+
+    def test_secondary_zero_shift(self):
+        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
+        assert peak1_sec_shift0 == pytest.approx(0, abs=2)
+        assert peak2_sec_shift0 == pytest.approx(304, abs=1)
+
+    def test_secondary_nonzero_shift(self):
+        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
+        assert peak1_sec_shift200 == pytest.approx(0, abs=2)
+        assert peak2_sec_shift200 == pytest.approx(304, abs=1)
+
+
+class Test03:
+    def setup_class(cls):
+        # Generate the Gaussians to use (identical peaks).
+        cls.gauss_1_peak = 5400.
+        cls.gauss_2_peak = 5400.
+        cls.xvals = np.linspace(5300., 5500., 1000)
+        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 4.)
+        cls.g2_y = norm.pdf(cls.xvals, cls.gauss_2_peak, 4.)
+        cls.obs_y = cls.g1_y + cls.g2_y
+        cls.mod1_y = cls.g1_y
+        cls.mod2_y = cls.g2_y
+
+        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
+
+        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
+                                  spectral_axis=cls.xvals * u.angstrom)
+        cls.obs_spec = PytodcorSpectrum(name="Case_03_Obs", air_or_vac="vacuum")
+        cls.obs_spec.add_spec_part(cls.obs_spec1d)
+
+        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod1_spec = PytodcorSpectrum(name="Case_03_Mod1", air_or_vac="vacuum")
+        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
+
+        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod2_spec = PytodcorSpectrum(name="Case_03_Mod2", air_or_vac="vacuum")
+        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
+
+        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
+            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
+            fixed_alpha=1., vel_range=[-500., 500.]
+        )
+        cls.x_fix_shift_1 = 0
+        cls.x_fix_shift_2 = cls.n_pix_apart
+        cls.y_fix_shift_1 = 0
+        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
+        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
+        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
+        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
+        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
+    # NO TOLERANCE -- PEAK SHOULD BE ZERO FOR ALL
+    def test_primary_zero_shift(self):
+        peak = (find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400)[0]
+        assert peak == 0
+
+    def test_primary_nonzero_shift(self):
+        peak = (find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400)[0]
+        assert peak == 0
+
+    def test_secondary_zero_shift(self):
+        peak = (find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400)[0]
+        assert peak == 0
+
+    def test_secondary_nonzero_shift(self):
+        peak = (find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400)[0]
+        assert peak == 0
+class Test04:
+    def setup_class(cls):
+        # Generate the Gaussians to use (smaller width, unequal amplitudes, different spectral range)
+        cls.gauss_1_peak = 4080.
+        cls.gauss_2_peak = 4120.
+        cls.xvals = np.linspace(4000., 4200., 1000)
+        cls.g1_y = norm.pdf(cls.xvals, cls.gauss_1_peak, 1.)
+        cls.g2_y = 0.1 * norm.pdf(cls.xvals, cls.gauss_2_peak, 1.)  # Second Gaussian has 10% amplitude
+        cls.obs_y = cls.g1_y + cls.g2_y
+        cls.mod1_y = cls.g1_y
+        cls.mod2_y = cls.g2_y
+
+        cls.n_pix_apart = len(np.where((cls.xvals >= cls.gauss_1_peak) & (cls.xvals <= cls.gauss_2_peak))[0])
+
+        cls.obs_spec1d = Spectrum(flux=cls.obs_y * u.dimensionless_unscaled,
+                                  spectral_axis=cls.xvals * u.angstrom)
+        cls.obs_spec = PytodcorSpectrum(name="Case_04_Obs", air_or_vac="vacuum")
+        cls.obs_spec.add_spec_part(cls.obs_spec1d)
+
+        cls.mod1_spec1d = Spectrum(flux=cls.mod1_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod1_spec = PytodcorSpectrum(name="Case_04_Mod1", air_or_vac="vacuum")
+        cls.mod1_spec.add_spec_part(cls.mod1_spec1d)
+
+        cls.mod2_spec1d = Spectrum(flux=cls.mod2_y * u.dimensionless_unscaled,
+                                   spectral_axis=cls.xvals * u.angstrom)
+        cls.mod2_spec = PytodcorSpectrum(name="Case_04_Mod2", air_or_vac="vacuum")
+        cls.mod2_spec.add_spec_part(cls.mod2_spec1d)
+
+        cls.todcor_pixshifts, cls.vel_per_pix, cls.todcor_vals, cls.todcor_alphas = todcor(
+            cls.obs_spec.parts[0], cls.mod1_spec.parts[0], cls.mod2_spec.parts[0], 400,
+            fixed_alpha=1., vel_range=[-500., 500.]
+        )
+        cls.x_fix_shift_1 = 0
+        cls.x_fix_shift_2 = cls.n_pix_apart
+        cls.y_fix_shift_1 = 0
+        cls.y_fix_shift_2 = -1 * cls.n_pix_apart
+        cls.where_x1 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_1)[0][0]
+        cls.where_x2 = np.where(cls.todcor_pixshifts == cls.x_fix_shift_2)[0][0]
+        cls.where_y1 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_1)[0][0]
+        cls.where_y2 = np.where(cls.todcor_pixshifts == cls.y_fix_shift_2)[0][0]
+
+    def test_primary_zero_shift(self):
+        peak1_pri_shift0, peak2_pri_shift0 = find_peaks(self.todcor_vals[self.where_x1, :])[0] - 400
+        assert peak1_pri_shift0 == pytest.approx(-204, abs=1)
+        assert peak2_pri_shift0 == pytest.approx(0, abs=1)
+
+    def test_primary_nonzero_shift(self):
+        peak1_pri_shift200, peak2_pri_shift200 = find_peaks(self.todcor_vals[self.where_x2, :])[0] - 400
+        assert peak1_pri_shift200 == pytest.approx(-204, abs=1)
+        assert peak2_pri_shift200 == pytest.approx(0, abs=1)
+
+    def test_secondary_zero_shift(self):
+        peak1_sec_shift0, peak2_sec_shift0 = find_peaks(self.todcor_vals[:, self.where_y1])[0] - 400
+        assert peak1_sec_shift0 == pytest.approx(0, abs=1)
+        assert peak2_sec_shift0 == pytest.approx(204, abs=1)
+
+    def test_secondary_nonzero_shift(self):
+        peak1_sec_shift200, peak2_sec_shift200 = find_peaks(self.todcor_vals[:, self.where_y2])[0] - 400
+        assert peak1_sec_shift200 == pytest.approx(0, abs=1)
+        assert peak2_sec_shift200 == pytest.approx(204, abs=1)

--- a/tests/basic/test_xcor1d.py
+++ b/tests/basic/test_xcor1d.py
@@ -19,3 +19,105 @@ def test_xcor1d_identical_gauss_no_shift():
     peak_lag = lag[peak_ind]
 
     assert peak_lag == 0
+def test_xcor1d_half_gauss_no_shift():
+    # Generate the Gaussians to use.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 50., 2.)
+    f2_x = np.arange(100)
+    f2_y = norm.pdf(f1_x, 50., 2.)
+    f2_y *= 0.5
+
+    # Calculate the one-dimensional cross-correlation.
+    corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
+    peak_ind = np.argmax(corr)
+    peak_val = corr[peak_ind]
+    peak_lag = lag[peak_ind]
+
+    assert peak_lag == 0
+def test_xcor1d_identical_gauss_shifted():
+    # Generate the Gaussians to use.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 30., 2.)
+    f2_x = np.arange(100)
+    f2_y = norm.pdf(f1_x, 60., 2.)
+
+    # Calculate the one-dimensional cross-correlation.
+    corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
+    peak_ind = np.argmax(corr)
+    peak_val = corr[peak_ind]
+    peak_lag = lag[peak_ind]
+
+    assert peak_lag == -30
+def test_xcor1d_identical_double_gauss_shifted():
+    # Generate the Gaussians to use.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 30., 2.)
+    f2_x = np.arange(100)
+    f2_y = norm.pdf(f1_x, 60., 2.)
+    f1_y += f2_y
+
+    # Calculate the one-dimensional cross-correlation.
+    corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
+    corr_sort_ind = np.flip(np.argsort(corr))
+    peak_val, peak_val_2 = corr[corr_sort_ind[0:2]]
+    peak_lag, peak_lag_2 = lag[corr_sort_ind[0:2]]
+    assert -30 in [peak_lag, peak_lag_2] and 0 in [peak_lag, peak_lag_2]
+def test_xcor1d_gauss_edge_shift():
+    # Generate the Gaussians to use, each at left or right edge.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 5., 2.)
+    f2_y = norm.pdf(f1_x, 95., 2.)
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == -90
+def test_xcor1d_rectangular_shifted():
+    # Generate the Gaussians to use.
+    f1_y = np.zeros(100)
+    f1_y[40:50] = 0.1
+    f2_y = np.zeros(100)
+    f2_y[60:70] = 0.1
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == -20
+def test_xcor1d_one_rectangular_shifted():
+    # Generate the Gaussians to use.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 60., 2.)
+    f2_y = np.zeros(100)
+    f2_y[10:20] = 0.1
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == pytest.approx(45,abs = 5) #since it is rectangular, the peak should be in this range
+def test_xcor1d_identical_gauss_negative_shift():
+    # Generate the Gaussians to use.
+    f1_x = np.arange(100)
+    f1_y = norm.pdf(f1_x, 80., 2.)
+    f2_x = np.arange(100)
+    f2_y = norm.pdf(f1_x, 20., 2.)
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == 60
+def test_xcor1d_identical_small():
+    f1_y = norm.pdf(np.arange(5), 2, 1.)
+    f2_y = norm.pdf(np.arange(5), 2, 1.)
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == 0
+def test_xcor1d_identical_small_shifted():
+    f1_y = norm.pdf(np.arange(5), 4, 1.)
+    f2_y = norm.pdf(np.arange(5), 1, 1.)
+    corr, lag = xcor1d(f1_y, f2_y)
+    peak_ind = np.argmax(corr)
+    peak_lag = lag[peak_ind]
+    assert peak_lag == 3

--- a/tests/basic/test_xcor1d.py
+++ b/tests/basic/test_xcor1d.py
@@ -15,10 +15,10 @@ def test_xcor1d_identical_gauss_no_shift():
 
     # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
-    peak_val = corr[peak_ind]
     peak_lag = lag[peak_ind]
 
     assert peak_lag == 0
+
 def test_xcor1d_half_gauss_no_shift():
     # Generate the Gaussians to use.
     f1_x = np.arange(100)
@@ -32,10 +32,10 @@ def test_xcor1d_half_gauss_no_shift():
 
     # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
-    peak_val = corr[peak_ind]
     peak_lag = lag[peak_ind]
 
     assert peak_lag == 0
+
 def test_xcor1d_identical_gauss_shifted():
     # Generate the Gaussians to use.
     f1_x = np.arange(100)
@@ -48,10 +48,10 @@ def test_xcor1d_identical_gauss_shifted():
 
     # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
-    peak_val = corr[peak_ind]
     peak_lag = lag[peak_ind]
 
     assert peak_lag == -30
+
 def test_xcor1d_identical_double_gauss_shifted():
     # Generate the Gaussians to use.
     f1_x = np.arange(100)
@@ -65,59 +65,98 @@ def test_xcor1d_identical_double_gauss_shifted():
 
     # Find the peak value (without fitting/interpolating between points):
     corr_sort_ind = np.flip(np.argsort(corr))
-    peak_val, peak_val_2 = corr[corr_sort_ind[0:2]]
     peak_lag, peak_lag_2 = lag[corr_sort_ind[0:2]]
     assert -30 in [peak_lag, peak_lag_2] and 0 in [peak_lag, peak_lag_2]
+
 def test_xcor1d_gauss_edge_shift():
     # Generate the Gaussians to use, each at left or right edge.
     f1_x = np.arange(100)
     f1_y = norm.pdf(f1_x, 5., 2.)
     f2_y = norm.pdf(f1_x, 95., 2.)
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
+    
     assert peak_lag == -90
+
 def test_xcor1d_rectangular_shifted():
-    # Generate the Gaussians to use.
+    # Generate the two square waves to use.
     f1_y = np.zeros(100)
     f1_y[40:50] = 0.1
     f2_y = np.zeros(100)
     f2_y[60:70] = 0.1
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
+
     assert peak_lag == -20
+
 def test_xcor1d_one_rectangular_shifted():
-    # Generate the Gaussians to use.
+    # Generate the Gaussian and square wave to use.
     f1_x = np.arange(100)
     f1_y = norm.pdf(f1_x, 60., 2.)
     f2_y = np.zeros(100)
     f2_y[10:20] = 0.1
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
-    assert peak_lag == pytest.approx(45,abs = 5) #since it is rectangular, the peak should be in this range
+
+    # Since it is rectangular, the peak should be in this range
+    assert peak_lag == pytest.approx(45, abs = 5)
+
 def test_xcor1d_identical_gauss_negative_shift():
     # Generate the Gaussians to use.
     f1_x = np.arange(100)
     f1_y = norm.pdf(f1_x, 80., 2.)
     f2_x = np.arange(100)
     f2_y = norm.pdf(f1_x, 20., 2.)
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
+
+    # Since it is rectangular, the peak should be in this range
     assert peak_lag == 60
+
 def test_xcor1d_identical_small():
+    # Generate the Gaussians to use.
     f1_y = norm.pdf(np.arange(5), 2, 1.)
     f2_y = norm.pdf(np.arange(5), 2, 1.)
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
+    
     assert peak_lag == 0
+
 def test_xcor1d_identical_small_shifted():
+    # Generate the Gaussians to use.
     f1_y = norm.pdf(np.arange(5), 4, 1.)
     f2_y = norm.pdf(np.arange(5), 1, 1.)
+
+    # Calculate the one-dimensional cross-correlation.
     corr, lag = xcor1d(f1_y, f2_y)
+
+    # Find the peak value (without fitting/interpolating between points):
     peak_ind = np.argmax(corr)
     peak_lag = lag[peak_ind]
+    
     assert peak_lag == 3

--- a/tox.ini
+++ b/tox.ini
@@ -43,11 +43,8 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-
     numpy210: numpy==2.1.*
-
     astropylts: astropy==6.0.*
-
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/psf/requests.git


### PR DESCRIPTION
Added Pytest unit tests for future GitHub Actions, covering `todcor` and `xcor1d`. Tests are organized using classes for clarity (`Test01`, `Test02`, etc) for `todcor` tests. 

Since `todcor` is not the fastest function, the tests may take some time to run. Used `pytest.approx` in the `todcor` tests due to the variability of the output, (203 vs 200) issue. This also applied to the test cases here. 